### PR TITLE
Introduce enum rule type

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -49,6 +49,11 @@ A `file` rule verifies that the field specified by the `field` property is empty
 If an `accept` property is specified, the file type must match one of file types that the property defines.
 
 
+## enum
+
+An `enum` rule verifies that the field specified by the `field` property is empty or that it has a value exactly the same as one of the array items specified by the `accept` property.
+
+
 ## minlength
 
 A `minlength` rule verifies that the total number of characters (as UTF-16 code units) in value of the fields specified by the `field` property is more than or equal to the number specified by the `threshold` property.

--- a/rules/enum.js
+++ b/rules/enum.js
@@ -1,0 +1,13 @@
+import { ValidationError } from '../error';
+
+export const enumeration = function ( formDataTree ) {
+	const values = formDataTree.getAll( this.field );
+
+	const isAcceptableValue = value => this.accept?.some(
+		acceptableValue => value === String( acceptableValue )
+	);
+
+	if ( ! values.every( isAcceptableValue ) ) {
+		throw new ValidationError( this );
+	}
+};

--- a/rules/index.js
+++ b/rules/index.js
@@ -6,6 +6,7 @@ export { tel } from './tel';
 export { number } from './number';
 export { date } from './date';
 export { file } from './file';
+export { enumeration as "enum" } from './enum';
 export { minlength } from './minlength';
 export { maxlength } from './maxlength';
 export { minnumber } from './minnumber';


### PR DESCRIPTION
#11

`enum` is a [reserved identifier](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Reserved_identifier), so the validator function needs to be renamed to `enumeration`.